### PR TITLE
load after Alpha Biomes and Too Many Mods

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -14,11 +14,13 @@
 		<li>Ludeon.Rimworld.Biotech</li>
 		<li>Ludeon.Rimworld.Anomaly</li>
 		<li>sarg.magicalmenagerie</li>
+		<li>sarg.alphabiomes</li>
 		<li>rooboid.minotaur</li>
 		<li>rooboid.faun</li>
 		<li>rooboid.satyr</li>
 		<li>dankpyon.medieval.overhaul</li>
 		<li>det.epochspyrinth</li>
 		<li>rooboid.satyrfaun.expanded</li>
+		<li>wara.toomanymods</li>
 	</loadAfter>
 </ModMetaData>


### PR DESCRIPTION
This pull request updates the mod load order in the `About/About.xml` file by adding two new mods to the `loadAfter` list. This is to ensure that the patches related the `MM_WildMinotaur` def are executed in the correct order to remove it cleanly without throwing exceptions.

### Additions to the `loadAfter` list:
* Added `sarg.alphabiomes`
* Added `wara.toomanymods`